### PR TITLE
Add settings screen for ChatPress widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,17 @@ The plugin:
 - Enqueues `chatpress-widget.js` (served from the plugin’s `assets/` directory) on the frontend.
 - Localises default options via `window.ChatPressConfig`.
 - Registers a `[chatpress_widget]` shortcode so you can control where the script loads.
+- Adds a **Settings → ChatPress Widget** screen to store your OpenAI API key, sitemap/REST endpoint and default model.
+
+### Configuring the plugin
+
+After activating the plugin, visit **Settings → ChatPress Widget** and complete the fields:
+
+1. **OpenAI API key** – required for the ChatPress assistant to make API calls.
+2. **Sitemap / REST URL** – optional URL that points to a sitemap or JSON search endpoint used for additional grounding context.
+3. **OpenAI model** – defaults to `gpt-4o-mini`; override if your account uses a different model name.
+
+These settings are exposed to the frontend via `window.ChatPressConfig` so the widget can authenticate and fetch supplemental content. You can still override any option at runtime via filters, shortcodes or the global `ChatPressConfig` object if needed.
 
 Example shortcode usage inside a post or template:
 

--- a/wordpress/chatpress-plugin.php
+++ b/wordpress/chatpress-plugin.php
@@ -13,6 +13,209 @@ if (!defined('ABSPATH')) {
 }
 
 define('CHATPRESS_WIDGET_VERSION', '1.0.0');
+define('CHATPRESS_WIDGET_OPTION_NAME', 'chatpress_widget_settings');
+
+/**
+ * Return the default settings stored via the WordPress Settings API.
+ *
+ * @return array
+ */
+function chatpress_widget_get_default_settings() {
+    return array(
+        'openai_api_key' => '',
+        'sitemap_url'    => '',
+        'model'          => 'gpt-4o-mini',
+    );
+}
+
+/**
+ * Retrieve plugin settings merged with defaults.
+ *
+ * @return array
+ */
+function chatpress_widget_get_settings() {
+    $settings = get_option(CHATPRESS_WIDGET_OPTION_NAME, array());
+
+    if (!is_array($settings)) {
+        $settings = array();
+    }
+
+    return wp_parse_args($settings, chatpress_widget_get_default_settings());
+}
+
+/**
+ * Sanitize Settings API submissions.
+ *
+ * @param array $input Raw option data.
+ * @return array
+ */
+function chatpress_widget_sanitize_settings($input) {
+    $defaults  = chatpress_widget_get_default_settings();
+    $sanitized = array();
+
+    if (isset($input['openai_api_key'])) {
+        $sanitized['openai_api_key'] = sanitize_text_field(wp_unslash($input['openai_api_key']));
+    }
+
+    if (isset($input['sitemap_url'])) {
+        $sanitized['sitemap_url'] = esc_url_raw(wp_unslash($input['sitemap_url']));
+    }
+
+    if (isset($input['model'])) {
+        $sanitized['model'] = sanitize_text_field(wp_unslash($input['model']));
+    }
+
+    $sanitized = wp_parse_args($sanitized, $defaults);
+
+    if ('' === $sanitized['model']) {
+        $sanitized['model'] = $defaults['model'];
+    }
+
+    return $sanitized;
+}
+
+/**
+ * Register the settings page, sections and fields.
+ */
+function chatpress_widget_register_settings() {
+    register_setting(
+        'chatpress_widget',
+        CHATPRESS_WIDGET_OPTION_NAME,
+        array(
+            'type'              => 'array',
+            'sanitize_callback' => 'chatpress_widget_sanitize_settings',
+            'default'           => chatpress_widget_get_default_settings(),
+        )
+    );
+
+    add_settings_section(
+        'chatpress_widget_main',
+        __('Assistant configuration', 'chatpress-widget'),
+        'chatpress_widget_settings_section_intro',
+        'chatpress_widget'
+    );
+
+    add_settings_field(
+        'chatpress_openai_api_key',
+        __('OpenAI API key', 'chatpress-widget'),
+        'chatpress_widget_render_api_key_field',
+        'chatpress_widget',
+        'chatpress_widget_main'
+    );
+
+    add_settings_field(
+        'chatpress_sitemap_url',
+        __('Sitemap / REST URL', 'chatpress-widget'),
+        'chatpress_widget_render_sitemap_field',
+        'chatpress_widget',
+        'chatpress_widget_main'
+    );
+
+    add_settings_field(
+        'chatpress_model',
+        __('OpenAI model', 'chatpress-widget'),
+        'chatpress_widget_render_model_field',
+        'chatpress_widget',
+        'chatpress_widget_main'
+    );
+}
+add_action('admin_init', 'chatpress_widget_register_settings');
+
+/**
+ * Render Settings API section intro copy.
+ */
+function chatpress_widget_settings_section_intro() {
+    echo '<p>' . esc_html__(
+        'Provide your ChatPress API credentials and content source so the widget can answer site-specific questions.',
+        'chatpress-widget'
+    ) . '</p>';
+}
+
+/**
+ * Render the OpenAI API key field.
+ */
+function chatpress_widget_render_api_key_field() {
+    $settings = chatpress_widget_get_settings();
+
+    printf(
+        '<input type="password" id="chatpress_openai_api_key" name="%1$s[openai_api_key]" value="%2$s" class="regular-text" autocomplete="off" />',
+        esc_attr(CHATPRESS_WIDGET_OPTION_NAME),
+        esc_attr($settings['openai_api_key'])
+    );
+    echo '<p class="description">' . esc_html__(
+        'Used by the frontend widget to call the ChatPress API via OpenAI.',
+        'chatpress-widget'
+    ) . '</p>';
+}
+
+/**
+ * Render the sitemap/REST URL field.
+ */
+function chatpress_widget_render_sitemap_field() {
+    $settings = chatpress_widget_get_settings();
+
+    printf(
+        '<input type="url" id="chatpress_sitemap_url" name="%1$s[sitemap_url]" value="%2$s" class="regular-text" placeholder="https://example.com/wp-json/wp/v2/search" />',
+        esc_attr(CHATPRESS_WIDGET_OPTION_NAME),
+        esc_attr($settings['sitemap_url'])
+    );
+    echo '<p class="description">' . esc_html__(
+        'Optional. Point to a sitemap or JSON endpoint used to fetch additional context for answers.',
+        'chatpress-widget'
+    ) . '</p>';
+}
+
+/**
+ * Render the OpenAI model field.
+ */
+function chatpress_widget_render_model_field() {
+    $settings = chatpress_widget_get_settings();
+
+    printf(
+        '<input type="text" id="chatpress_model" name="%1$s[model]" value="%2$s" class="regular-text" placeholder="gpt-4o-mini" />',
+        esc_attr(CHATPRESS_WIDGET_OPTION_NAME),
+        esc_attr($settings['model'])
+    );
+    echo '<p class="description">' . esc_html__(
+        'Defaults to gpt-4o-mini. Override to use a different OpenAI model identifier.',
+        'chatpress-widget'
+    ) . '</p>';
+}
+
+/**
+ * Register the settings page in the WordPress admin.
+ */
+function chatpress_widget_add_settings_page() {
+    add_options_page(
+        __('ChatPress Widget', 'chatpress-widget'),
+        __('ChatPress Widget', 'chatpress-widget'),
+        'manage_options',
+        'chatpress-widget',
+        'chatpress_widget_render_settings_page'
+    );
+}
+add_action('admin_menu', 'chatpress_widget_add_settings_page');
+
+/**
+ * Output the settings page markup.
+ */
+function chatpress_widget_render_settings_page() {
+    if (!current_user_can('manage_options')) {
+        return;
+    }
+
+    echo '<div class="wrap">';
+    echo '<h1>' . esc_html__('ChatPress Widget settings', 'chatpress-widget') . '</h1>';
+
+    settings_errors('chatpress_widget');
+
+    echo '<form action="options.php" method="post">';
+    settings_fields('chatpress_widget');
+    do_settings_sections('chatpress_widget');
+    submit_button();
+    echo '</form>';
+    echo '</div>';
+}
 
 /**
  * Register the widget script so it can be enqueued when needed.
@@ -28,6 +231,8 @@ add_action('wp_enqueue_scripts', 'chatpress_widget_register_assets');
 /**
  * Enqueue the script and push default configuration to the frontend.
  *
+ * Stored settings from the admin screen are merged into the defaults before localisation.
+ *
  * @param array $overrides Optional configuration overrides passed from the shortcode or theme.
  */
 function chatpress_widget_enqueue($overrides = array()) {
@@ -41,10 +246,15 @@ function chatpress_widget_enqueue($overrides = array()) {
         chatpress_widget_register_assets();
     }
 
+    $settings = chatpress_widget_get_settings();
+
     $defaults = array(
         'brandColor' => '#2563eb',
         'greeting'   => __('Hi there! Ask me anything about this site.', 'chatpress-widget'),
         'position'   => 'bottom-right',
+        'openAiApiKey' => $settings['openai_api_key'],
+        'sitemapUrl'   => $settings['sitemap_url'],
+        'model'        => $settings['model'],
     );
 
     $config = wp_parse_args($overrides, apply_filters('chatpress_widget_default_config', $defaults));


### PR DESCRIPTION
## Summary
- add a Settings → ChatPress Widget admin page that stores the API key, sitemap endpoint, and model via the WordPress Settings API
- merge the saved settings into the localized ChatPressConfig defaults consumed on the frontend
- document the new configuration workflow in the README and inline code comments

## Testing
- php -l wordpress/chatpress-plugin.php

------
https://chatgpt.com/codex/tasks/task_e_68c8e9d4d798832a928b37ac89a3b0a1